### PR TITLE
backup_chef: Do not install knife-ec-backup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,29 +1,30 @@
 AllCops:
-  Include:
-    - Berksfile
-    - Gemfile
-    - Rakefile
   Exclude:
-    - test/**/*
     - vendor/**/*
 
+AlignParameters:
+  Enabled: false
+ClassLength:
+  Enabled: false
+CyclomaticComplexity:
+  Enabled: false
+Documentation:
+  Enabled: false
+Encoding:
+  Enabled: false
+Style/FileName:
+  Enabled: false
 LineLength:
   Enabled: false
-SingleSpaceBeforeFirstArg:
-  Exclude:
-    - '**/metadata.rb'
-HashSyntax:
-  Enabled: false
-
-AlignParameters:
-  Exclude:
-    - '**/metadata.rb'
-
 MethodLength:
   Enabled: false
-
-AbcSize:
+Metrics/AbcSize:
   Enabled: false
-
-Documentation:
+PerceivedComplexity:
+  Enabled: false
+Style/SpaceBeforeFirstArg:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/FileName:
   Enabled: false

--- a/libraries/provider_backup_chef.rb
+++ b/libraries/provider_backup_chef.rb
@@ -27,15 +27,6 @@ class Chef
         def action_create
           include_recipe 'build-essential::default'
 
-          # I did it, because chef_gem not support the setting of environment variables.
-          execute 'install knife-ec-backup gem' do
-            command '/opt/chef/embedded/bin/gem install knife-ec-backup -q --no-rdoc --no-ri'
-            environment 'PATH' => "#{ENV['PATH']}:/opt/opscode/embedded/bin",
-                        'C_INCLUDE_PATH' => '/opt/opscode/embedded/postgresql/9.2/include'
-            action :run
-            not_if '/opt/chef/embedded/bin/gem list | grep "knife-ec-backup"'
-          end
-
           super
           create_prejob_script
           create_postjob_script
@@ -55,7 +46,7 @@ class Chef
 
         def create_prejob_script
           backup_string = "#!/bin/bash\n"
-          backup_string += 'knife ec backup '
+          backup_string += '/opt/opscode/embedded/bin/knife ec backup '
           backup_string += "-s #{new_resource.url} " if new_resource.url
           backup_string += "#{new_resource.files[0]} "
           backup_string += "> /dev/null\n"


### PR DESCRIPTION
It is bundled with chef-server, so we don' have to install it to the local ChefDK environment
cc: @Kasen 
